### PR TITLE
Adding a fixed height to recipe images

### DIFF
--- a/src/app/recipe-list/recipe-list.component.css
+++ b/src/app/recipe-list/recipe-list.component.css
@@ -1,0 +1,3 @@
+.recipe img {
+  height: 230px;
+}


### PR DESCRIPTION
This prevents the content from jumping as the images load.