### PR TITLE
Fixing search so it doesn't over-match adjacent elements

### DIFF
--- a/src/app/_pipes/search/search.pipe.spec.ts
+++ b/src/app/_pipes/search/search.pipe.spec.ts
@@ -25,6 +25,28 @@ describe('SearchPipe', () => {
       .toBe(1);
   });
 
+  it('should match recipe titles regardless of letter case', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'the BAR recipe',
+          ingredients: ['baz', 'the foo ingredient'],
+        },
+      ], ['bar']).length)
+      .toBe(1);
+  });
+
+  it('should match recipe titles regardless of letter case', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'the bar recipe',
+          ingredients: ['baz', 'the FOO ingredient'],
+        },
+      ], ['foo']).length)
+      .toBe(1);
+  });
+
   it('should not match recipes that do not contain keyword', () => {
     expect(
       pipe.transform([
@@ -33,6 +55,50 @@ describe('SearchPipe', () => {
           ingredients: ['baz', 'bam'],
         },
       ], ['foo']).length)
+      .toBe(0);
+  });
+
+  it('should match recipes where both keywords match', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'apple bacon chips',
+          ingredients: ['foo', 'bar'],
+        },
+      ], ['apple', 'bacon']).length)
+      .toBe(1);
+  });
+
+  it('should not match recipes where only one keyword matches', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'apple bacon chips',
+          ingredients: ['foo', 'bar'],
+        },
+      ], ['apple', 'banana']).length)
+      .toBe(0);
+  });
+
+  it('should not match ingredients that only match when concatenated', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'holiday chocolate surprise',
+          ingredients: ['chocolate', 'caramel'],
+        },
+      ], ['chocolatecaramel']).length)
+      .toBe(0);
+  });
+
+  it('should not match recipes that only match when concatenating title and first ingredient', () => {
+    expect(
+      pipe.transform([
+        {
+          title: 'holiday chocolate surprise',
+          ingredients: ['chocolate', 'caramel'],
+        },
+      ], ['surprisechocolate']).length)
       .toBe(0);
   });
 });

--- a/src/app/_pipes/search/search.pipe.ts
+++ b/src/app/_pipes/search/search.pipe.ts
@@ -6,12 +6,15 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class SearchPipe implements PipeTransform {
 
   private matchesRecipe = (recipe, keywords) => {
-    let words = recipe.title.toLowerCase();
+    // Concatenate all recipe words together, separating elements with single
+    // spaces.
+    let words = recipe.title;
     if (recipe.ingredients) {
-      recipe.ingredients.forEach((ingredient) => {
-        words += ingredient.toLowerCase();
-      });
+      words += ' ' + recipe.ingredients.join(' ');
     }
+    words = words.toLowerCase();
+
+    // Search target string for each keyword.
     for (let i = 0; i < keywords.length; i += 1) {
       if (words.indexOf(keywords[i]) === -1) {
         return false;


### PR DESCRIPTION
There was a bug in the search that caused a recipe like "Carrot Cake" with
ingredients Sugar to match the keyword "cakesugar" when it should not.

Fixes #84