### PR TITLE
Fixing <mark> padding

### DIFF
--- a/src/app/_components/recipe-list/recipe-list.component.css
+++ b/src/app/_components/recipe-list/recipe-list.component.css
@@ -40,10 +40,3 @@ button.recipe-categories {
 .recipe {
   margin-bottom: 10px;
 }
-
-mark {
-  display: inline;
-  margin: 0;
-  padding: 0;
-  font-weight: 600;
-}

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -44,3 +44,10 @@ a:link, a:active, a:visited {
   cursor: pointer;
   color: inherit;
 }
+
+mark {
+  display: inline;
+  margin: 0px !important;
+  padding: 0px !important;
+  font-weight: 600;
+}


### PR DESCRIPTION
For some reason, the mark CSS doesn't take effect in the component-specific
CSS. Moving it back to globals.

Fixes #128.