### PR TITLE
Prevent keyword from canceling out exclusions that it's a substring of

### DIFF
--- a/src/app/_pipes/parse-search-query/parse-search-query.pipe.spec.ts
+++ b/src/app/_pipes/parse-search-query/parse-search-query.pipe.spec.ts
@@ -32,6 +32,10 @@ describe('ParseSearchQueryPipe', () => {
     expect(pipe.transform('chicken chick')).toEqual(new SearchParams(['chicken'], []));
   });
 
+  it('should handle a keyword that is a substring of excluded terms', () => {
+    expect(pipe.transform('bread -shortbread -gingerbread')).toEqual(new SearchParams(['bread'], ['shortbread', 'gingerbread']));
+  });
+
   it('should ignore duplicate keywords', () => {
     expect(pipe.transform('duck duck goose')).toEqual(new SearchParams(['duck', 'goose'], []));
   });


### PR DESCRIPTION
If query is "bread -shortbread -gingerbread" the "bread" keyword is not a
substring of "shortbread" because they're separate types of tokens.

Related to #150