### PR TITLE
Removing sourcemaps flag from npm coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "ng serve",
     "build": "ng build --target=production --aot",
-    "coverage": "ng test --environment=dev --no-watch --code-coverage --single-run=true --sourcemaps=false",
+    "coverage": "ng test --environment=dev --no-watch --code-coverage --single-run=true",
     "lint": "ng lint && scssfmt --recursive './src/**/**/*.scss' --diff",
     "e2e": "ng e2e",
     "update-deps": "npm update"


### PR DESCRIPTION
Tests still pass without it, so removing it